### PR TITLE
fix: repalcement txs check inside for loop

### DIFF
--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -953,6 +953,46 @@ class Mempool extends EventEmitter {
         0);
     }
 
+    // If we reject RBF transactions altogether we can skip these checks,
+    // because incoming conflicts are already rejected as double spends.
+    if (this.options.replaceByFee) {
+      const conflicts = this.getConflicts(tx);
+      let conflictingFees = 0;
+
+      // Replacement TXs must pay a higher fee rate than each conflicting TX.
+      // We compare using deltaFee to account for prioritiseTransaction()
+      for (const conflict of conflicts) {
+        conflictingFees += conflict.descFee;
+
+        if (entry.getDeltaRate() <= conflict.getDeltaRate()) {
+          throw new VerifyError(tx,
+          'insufficientfee',
+          'insufficient fee',
+          0);
+        }
+      }
+
+      // Replacement TX must also pay for the total fees of all descendant
+      // transactions that will be evicted if an ancestor is replaced.
+      // Thus the replacement "pays for the bandwidth" of all the conflicts.
+      if (entry.deltaFee <= conflictingFees) {
+        throw new VerifyError(tx,
+        'insufficientfee',
+        'insufficient fee',
+        0);
+      }
+
+      // Once the conflicts are all paid for, the replacement TX fee
+      // still needs to cover it's own bandwidth.
+      const feeRemaining = entry.deltaFee - conflictingFees;
+      if (feeRemaining < minFee) {
+        throw new VerifyError(tx,
+          'insufficientfee',
+          'insufficient fee',
+          0);
+      }
+    }
+
     // Contextual sanity checks.
     const [fee, reason, score] = tx.checkInputs(view, height);
 
@@ -1666,6 +1706,27 @@ class Mempool extends EventEmitter {
     }
 
     return false;
+  }
+
+  /**
+   * Get an array of all transactions currently in the mempool that
+   * spend one or more of the same outputs as an incoming transaction.
+   * @param {TX} tx
+   * @returns {Promise} - Returns (@link MempoolEntry}[].
+   */
+
+  getConflicts(tx) {
+    const conflicts = [];
+
+    for (const {prevout} of tx.inputs) {
+      const {hash, index} = prevout;
+      const conflict = this.getSpent(hash, index);
+
+      if (conflict && conflicts.indexOf(conflict) === -1)
+        conflicts.push(conflict);
+    }
+
+    return conflicts;
   }
 
   /**

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -1659,7 +1659,9 @@ class Mempool extends EventEmitter {
   isDoubleSpend(tx) {
     for (const {prevout} of tx.inputs) {
       const {hash, index} = prevout;
-      if (this.isSpent(hash, index))
+      const conflict = this.getSpent(hash, index);
+
+      if (conflict && !conflict.tx.isRBF())
         return true;
     }
 

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -846,10 +846,10 @@ class Mempool extends EventEmitter {
     // Contextual verification.
     const conflicts = await this.verify(entry, view);
 
-    // Remove conflicting TXs and their descendants
-    if (conflicts.length) {
-      assert(this.options.replaceByFee);
-
+    // RBF only: Remove conflicting TXs and their descendants
+    if (!this.options.replaceByFee) {
+      assert(conflicts.length === 0);
+    } else {
       for (const conflict of conflicts) {
         this.logger.debug(
           'Replacing tx %h with %h',

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -1759,13 +1759,16 @@ class Mempool extends EventEmitter {
 
   getConflicts(tx) {
     const conflicts = [];
+    const hashes = new BufferSet();
 
     for (const {prevout} of tx.inputs) {
       const {hash, index} = prevout;
       const conflict = this.getSpent(hash, index);
 
-      if (conflict && conflicts.indexOf(conflict) === -1)
+      if (conflict && !hashes.has(hash)) {
+        hashes.add(hash);
         conflicts.push(conflict);
+      }
     }
 
     return conflicts;

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -844,7 +844,20 @@ class Mempool extends EventEmitter {
     const entry = MempoolEntry.fromTX(tx, view, height);
 
     // Contextual verification.
-    await this.verify(entry, view);
+    const conflicts = await this.verify(entry, view);
+
+    // Remove conflicting TXs and their descendants
+    if (conflicts.length) {
+      assert(this.options.replaceByFee);
+
+      for (const conflict of conflicts) {
+        this.logger.debug(
+          'Replacing tx %h with %h',
+          conflict.tx.hash(),
+          tx.hash());
+        this.evictEntry(conflict);
+      }
+    }
 
     // Add and index the entry.
     await this.addEntry(entry, view);
@@ -862,10 +875,11 @@ class Mempool extends EventEmitter {
 
   /**
    * Verify a transaction with mempool standards.
+   * Returns an array of conflicting TXs
    * @method
    * @param {TX} tx
    * @param {CoinView} view
-   * @returns {Promise}
+   * @returns {Promise} - Returns {@link MempoolEntry}[]
    */
 
   async verify(entry, view) {
@@ -1061,6 +1075,8 @@ class Mempool extends EventEmitter {
       assert(await this.verifyResult(tx, view, flags),
         'BUG: Verify failed for mandatory but not standard.');
     }
+
+    return conflicts;
   }
 
   /**

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -955,14 +955,19 @@ class Mempool extends EventEmitter {
 
     // If we reject RBF transactions altogether we can skip these checks,
     // because incoming conflicts are already rejected as double spends.
-    if (this.options.replaceByFee) {
-      const conflicts = this.getConflicts(tx);
+    let conflicts = [];
+    if (this.options.replaceByFee)
+      conflicts = this.getConflicts(tx);
+
+    if (conflicts.length) {
       let conflictingFees = 0;
+      let totalEvictions = 0;
 
       // Replacement TXs must pay a higher fee rate than each conflicting TX.
       // We compare using deltaFee to account for prioritiseTransaction()
       for (const conflict of conflicts) {
         conflictingFees += conflict.descFee;
+        totalEvictions += this.countDescendants(conflict) + 1;
 
         if (entry.getDeltaRate() <= conflict.getDeltaRate()) {
           throw new VerifyError(tx,
@@ -970,6 +975,14 @@ class Mempool extends EventEmitter {
           'insufficient fee',
           0);
         }
+      }
+
+      // Replacement TXs must not evict/replace more than 100 descendants
+      if (totalEvictions > 100) {
+        throw new VerifyError(tx,
+        'nonstandard',
+        'too many potential replacements',
+        0);
       }
 
       // Replacement TX must also pay for the total fees of all descendant
@@ -990,6 +1003,19 @@ class Mempool extends EventEmitter {
           'insufficientfee',
           'insufficient fee',
           0);
+      }
+
+      // Replacement TXs can not consume any unconfirmed outputs that were not
+      // already included in the original transactions. They can only add
+      // confirmed UTXO, saving the trouble of checking new mempool ancestors.
+      for (const {prevout} of tx.inputs) {
+        if (!this.isSpent(prevout.hash, prevout.index) &&
+            this.map.has(prevout.hash)) {
+          throw new VerifyError(tx,
+            'nonstandard',
+            'replacement-adds-unconfirmed',
+            0);
+        }
       }
     }
 

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -983,20 +983,20 @@ class Mempool extends EventEmitter {
         conflictingFees += conflict.descFee;
         totalEvictions += this.countDescendants(conflict) + 1;
 
+        // Replacement TXs must not evict/replace more than 100 descendants
+        if (totalEvictions > 100) {
+          throw new VerifyError(tx,
+          'nonstandard',
+          'too many potential replacements',
+          0);
+        }
+
         if (entry.getDeltaRate() <= conflict.getDeltaRate()) {
           throw new VerifyError(tx,
           'insufficientfee',
           'insufficient fee',
           0);
         }
-      }
-
-      // Replacement TXs must not evict/replace more than 100 descendants
-      if (totalEvictions > 100) {
-        throw new VerifyError(tx,
-        'nonstandard',
-        'too many potential replacements',
-        0);
       }
 
       // Replacement TX must also pay for the total fees of all descendant

--- a/test/mempool-test.js
+++ b/test/mempool-test.js
@@ -1055,4 +1055,190 @@ describe('Mempool', function() {
         throw err;
     });
   });
+
+  describe('Replace-by-fee', function () {
+    const blocks = new BlockStore({
+      memory: true
+    });
+
+    const chain = new Chain({
+      memory: true,
+      blocks
+    });
+
+    const mempool = new Mempool({
+      chain,
+      memory: true
+    });
+
+    before(async () => {
+      await blocks.open();
+      await mempool.open();
+      await chain.open();
+    });
+
+    after(async () => {
+      await chain.close();
+      await mempool.close();
+      await blocks.close();
+    });
+
+    beforeEach(async () => {
+      await mempool.reset();
+      assert.strictEqual(mempool.map.size, 0);
+    });
+
+    // Number of coins available in
+    // chaincoins (100k satoshi per coin).
+    const N = 100;
+    const chaincoins = new MemWallet();
+    const wallet = new MemWallet();
+
+    it('should create coins in chain', async () => {
+      const mtx = new MTX();
+      mtx.addInput(new Input());
+
+      for (let i = 0; i < N; i++) {
+        const addr = chaincoins.createReceive().getAddress();
+        mtx.addOutput(addr, 100000);
+      }
+
+      const cb = mtx.toTX();
+      const block = await getMockBlock(chain, [cb], false);
+      const entry = await chain.add(block, VERIFY_NONE);
+
+      await mempool._addBlock(entry, block.txs);
+
+      // Add 100 blocks so we don't get
+      // premature spend of coinbase.
+      for (let i = 0; i < 100; i++) {
+        const block = await getMockBlock(chain);
+        const entry = await chain.add(block, VERIFY_NONE);
+
+        await mempool._addBlock(entry, block.txs);
+      }
+
+      chaincoins.addTX(cb);
+    });
+
+    it('should not accept RBF tx', async() => {
+      mempool.options.replaceByFee = false;
+
+      const mtx = new MTX();
+      const coin = chaincoins.getCoins()[0];
+      mtx.addCoin(coin);
+      mtx.inputs[0].sequence = 0xfffffffd;
+
+      const addr = wallet.createReceive().getAddress();
+      mtx.addOutput(addr, 90000);
+
+      chaincoins.sign(mtx);
+
+      assert(mtx.verify());
+      const tx = mtx.toTX();
+
+      await assert.rejects(async () => {
+        await mempool.addTX(tx);
+      }, {
+        type: 'VerifyError',
+        reason: 'replace-by-fee'
+      });
+
+      assert(!mempool.hasCoin(tx.hash(), 0));
+      assert.strictEqual(mempool.map.size, 0);
+    });
+
+    it('should accept RBF tx with RBF option enabled', async() => {
+      mempool.options.replaceByFee = true;
+
+      const mtx = new MTX();
+      const coin = chaincoins.getCoins()[0];
+      mtx.addCoin(coin);
+      mtx.inputs[0].sequence = 0xfffffffd;
+
+      const addr = wallet.createReceive().getAddress();
+      mtx.addOutput(addr, coin.value - 1000);
+
+      chaincoins.sign(mtx);
+
+      assert(mtx.verify());
+      const tx = mtx.toTX();
+
+      await mempool.addTX(tx);
+
+      assert(mempool.hasCoin(tx.hash(), 0));
+      assert.strictEqual(mempool.map.size, 1);
+    });
+
+    it('should reject double spend without RBF from mempool', async() => {
+      mempool.options.replaceByFee = true;
+
+      const coin = chaincoins.getCoins()[0];
+
+      const mtx1 = new MTX();
+      const mtx2 = new MTX();
+      mtx1.addCoin(coin);
+      mtx2.addCoin(coin);
+
+      const addr1 = wallet.createReceive().getAddress();
+      mtx1.addOutput(addr1, coin.value - 1000);
+
+      const addr2 = wallet.createReceive().getAddress();
+      mtx2.addOutput(addr2, coin.value - 1000);
+
+      chaincoins.sign(mtx1);
+      chaincoins.sign(mtx2);
+
+      assert(mtx1.verify());
+      assert(mtx2.verify());
+      const tx1 = mtx1.toTX();
+      const tx2 = mtx2.toTX();
+
+      assert(!tx1.isRBF());
+
+      await mempool.addTX(tx1);
+
+      await assert.rejects(async () => {
+        await mempool.addTX(tx2);
+      }, {
+        type: 'VerifyError',
+        reason: 'bad-txns-inputs-spent'
+      });
+
+      assert(mempool.hasCoin(tx1.hash(), 0));
+      assert.strictEqual(mempool.map.size, 1);
+    });
+
+    it('should accept double spend with RBF into mempool', async() => {
+      mempool.options.replaceByFee = true;
+
+      const coin = chaincoins.getCoins()[0];
+
+      const mtx1 = new MTX();
+      const mtx2 = new MTX();
+      mtx1.addCoin(coin);
+      mtx2.addCoin(coin);
+
+      mtx1.inputs[0].sequence = 0xfffffffd;
+
+      const addr1 = wallet.createReceive().getAddress();
+      mtx1.addOutput(addr1, coin.value - 1000);
+
+      const addr2 = wallet.createReceive().getAddress();
+      mtx2.addOutput(addr2, coin.value - 1000);
+
+      chaincoins.sign(mtx1);
+      chaincoins.sign(mtx2);
+
+      assert(mtx1.verify());
+      assert(mtx2.verify());
+      const tx1 = mtx1.toTX();
+      const tx2 = mtx2.toTX();
+
+      assert(tx1.isRBF());
+
+      await mempool.addTX(tx1);
+      await mempool.addTX(tx2);
+    });
+  });
 });

--- a/test/mempool-test.js
+++ b/test/mempool-test.js
@@ -1290,5 +1290,106 @@ describe('Mempool', function() {
         reason: 'insufficient fee'
       });
     });
+
+    it('should reject replacement including new unconfirmed UTXO', async() => {
+      mempool.options.replaceByFee = true;
+
+      const coin1 = chaincoins.getCoins()[0];
+      const coin2 = chaincoins.getCoins()[1];
+
+      const mtx1 = new MTX();
+      const mtx2 = new MTX();
+      mtx1.addCoin(coin1);
+      mtx2.addCoin(coin2);
+
+      mtx1.inputs[0].sequence = 0xfffffffd;
+
+      const addr1 = chaincoins.createReceive().getAddress();
+      mtx1.addOutput(addr1, coin1.value - 1000);
+
+      const addr2 = chaincoins.createReceive().getAddress();
+      mtx2.addOutput(addr2, coin2.value - 1000);
+
+      chaincoins.sign(mtx1);
+      chaincoins.sign(mtx2);
+
+      assert(mtx1.verify());
+      assert(mtx2.verify());
+      const tx1 = mtx1.toTX();
+      const tx2 = mtx2.toTX();
+
+      assert(tx1.isRBF());
+
+      await mempool.addTX(tx1);
+      await mempool.addTX(tx2);
+
+      // Attempt to replace tx1 and include the unconfirmed output of tx2
+      const mtx3 = new MTX();
+      mtx3.addCoin(coin1);
+      const coin3 = Coin.fromTX(tx2, 0, -1);
+      mtx3.addCoin(coin3);
+      const addr3 = wallet.createReceive().getAddress();
+      // Remember to bump the fee!
+      mtx3.addOutput(addr3, coin1.value + coin3.value - 2000);
+      chaincoins.sign(mtx3);
+      assert(mtx3.verify());
+      const tx3 = mtx3.toTX();
+
+      await assert.rejects(async () => {
+        await mempool.addTX(tx3);
+      }, {
+        type: 'VerifyError',
+        reason: 'replacement-adds-unconfirmed'
+      });
+    });
+
+    it('should reject replacement evicting too many descendants', async() => {
+      mempool.options.replaceByFee = true;
+
+      const addr1 = chaincoins.createReceive().getAddress();
+      const coin0 = chaincoins.getCoins()[0];
+      const coin1 = chaincoins.getCoins()[1];
+
+      // Generate big TX with 100 outputs
+      const mtx1 = new MTX();
+      mtx1.addCoin(coin0);
+      mtx1.addCoin(coin1);
+      mtx1.inputs[0].sequence = 0xfffffffd;
+      const outputValue = (coin0.value / 100) + (coin1.value / 100) - 100;
+      for (let i = 0; i < 100; i++)
+        mtx1.addOutput(addr1, outputValue);
+
+      chaincoins.sign(mtx1);
+      assert(mtx1.verify());
+      const tx1 = mtx1.toTX();
+      await mempool.addTX(tx1);
+
+      // Spend each of those outputs individually
+      for (let i = 0; i < 100; i++) {
+        const mtx = new MTX();
+        const coin = Coin.fromTX(tx1, i, -1);
+        mtx.addCoin(coin);
+        mtx.addOutput(addr1, coin.value - 1000);
+        chaincoins.sign(mtx);
+        assert(mtx.verify());
+        const tx = mtx.toTX();
+        await mempool.addTX(tx);
+      }
+
+      // Attempt to evict the whole batch by replacing the first TX (tx1)
+      const mtx2 = new MTX();
+      mtx2.addCoin(coin0);
+      mtx2.addOutput(addr1, coin0.value - 1000);
+      chaincoins.sign(mtx2);
+      assert(mtx2.verify());
+      const tx2 = mtx2.toTX();
+
+      await assert.rejects(async () => {
+        await mempool.addTX(tx2);
+      }, {
+        type: 'VerifyError',
+        reason: 'too many potential replacements'
+      });
+    });
   });
 });

--- a/test/mempool-test.js
+++ b/test/mempool-test.js
@@ -1209,7 +1209,7 @@ describe('Mempool', function() {
       assert.strictEqual(mempool.map.size, 1);
     });
 
-    it('should accept double spend with RBF into mempool', async() => {
+    it('should reject replacement with lower fee rate', async() => {
       mempool.options.replaceByFee = true;
 
       const coin = chaincoins.getCoins()[0];
@@ -1222,10 +1222,10 @@ describe('Mempool', function() {
       mtx1.inputs[0].sequence = 0xfffffffd;
 
       const addr1 = wallet.createReceive().getAddress();
-      mtx1.addOutput(addr1, coin.value - 1000);
+      mtx1.addOutput(addr1, coin.value - 1000); // 1000 satoshi fee
 
       const addr2 = wallet.createReceive().getAddress();
-      mtx2.addOutput(addr2, coin.value - 1000);
+      mtx2.addOutput(addr2, coin.value - 900); // 900 satoshi fee
 
       chaincoins.sign(mtx1);
       chaincoins.sign(mtx2);
@@ -1238,7 +1238,57 @@ describe('Mempool', function() {
       assert(tx1.isRBF());
 
       await mempool.addTX(tx1);
-      await mempool.addTX(tx2);
+
+      await assert.rejects(async () => {
+        await mempool.addTX(tx2);
+      }, {
+        type: 'VerifyError',
+        reason: 'insufficient fee'
+      });
+    });
+
+    it('should reject replacement that doesnt pay all child fees', async() => {
+      mempool.options.replaceByFee = true;
+
+      const addr1 = chaincoins.createReceive().getAddress();
+      const addr2 = wallet.createReceive().getAddress();
+      const originalCoin = chaincoins.getCoins()[0];
+      let coin = originalCoin;
+
+      // Generate chain of 10 transactions, each paying 1000 sat fee
+      for (let i = 0; i < 10; i++) {
+        const mtx = new MTX();
+        mtx.addCoin(coin);
+        mtx.inputs[0].sequence = 0xfffffffd;
+        mtx.addOutput(addr1, coin.value - 1000);
+        chaincoins.sign(mtx);
+        assert(mtx.verify());
+        const tx = mtx.toTX();
+        await mempool.addTX(tx);
+
+        coin = Coin.fromTX(tx, 0, -1);
+      }
+
+      // Pay for all child fees
+      let fee = 10 * 1000;
+
+      // Pay for its own bandwidth (estimating tx2 size as 200 bytes)
+      fee += mempool.options.minRelay * 0.2;
+
+      // Attempt to submit a replacement for the initial parent TX
+      const mtx2 = new MTX();
+      mtx2.addCoin(originalCoin);
+      mtx2.addOutput(addr2, originalCoin.value - fee + 100);
+      chaincoins.sign(mtx2);
+      assert(mtx2.verify());
+      const tx2 = mtx2.toTX();
+
+      await assert.rejects(async () => {
+        await mempool.addTX(tx2);
+      }, {
+        type: 'VerifyError',
+        reason: 'insufficient fee'
+      });
     });
   });
 });

--- a/test/mempool-test.js
+++ b/test/mempool-test.js
@@ -1245,6 +1245,20 @@ describe('Mempool', function() {
         type: 'VerifyError',
         reason: 'insufficient fee'
       });
+
+      // Try again with higher fee
+      const mtx3 = new MTX();
+      mtx3.addCoin(coin);
+      mtx3.addOutput(addr2, coin.value - 1200); // 1200 satoshi fee
+      chaincoins.sign(mtx3);
+      assert(mtx3.verify());
+      const tx3 = mtx3.toTX();
+
+      await mempool.addTX(tx3);
+
+      // tx1 has been replaced by tx3
+      assert(!mempool.has(tx1.hash()));
+      assert(mempool.has(tx3.hash()));
     });
 
     it('should reject replacement that doesnt pay all child fees', async() => {
@@ -1256,6 +1270,7 @@ describe('Mempool', function() {
       let coin = originalCoin;
 
       // Generate chain of 10 transactions, each paying 1000 sat fee
+      const childHashes = [];
       for (let i = 0; i < 10; i++) {
         const mtx = new MTX();
         mtx.addCoin(coin);
@@ -1265,6 +1280,8 @@ describe('Mempool', function() {
         assert(mtx.verify());
         const tx = mtx.toTX();
         await mempool.addTX(tx);
+
+        childHashes.push(tx.hash());
 
         coin = Coin.fromTX(tx, 0, -1);
       }
@@ -1289,6 +1306,21 @@ describe('Mempool', function() {
         type: 'VerifyError',
         reason: 'insufficient fee'
       });
+
+      // Try again with higher fee
+      const mtx3 = new MTX();
+      mtx3.addCoin(originalCoin);
+      mtx3.addOutput(addr2, originalCoin.value - fee);
+      chaincoins.sign(mtx3);
+      assert(mtx3.verify());
+      const tx3 = mtx3.toTX();
+
+      await mempool.addTX(tx3);
+
+      // All child TXs have been replaced by tx3
+      for (const hash of childHashes)
+        assert(!mempool.has(hash));
+      assert(mempool.has(tx3.hash()));
     });
 
     it('should reject replacement including new unconfirmed UTXO', async() => {
@@ -1365,6 +1397,8 @@ describe('Mempool', function() {
       await mempool.addTX(tx1);
 
       // Spend each of those outputs individually
+      let tx;
+      const hashes = [];
       for (let i = 0; i < 100; i++) {
         const mtx = new MTX();
         const coin = Coin.fromTX(tx1, i, -1);
@@ -1372,14 +1406,19 @@ describe('Mempool', function() {
         mtx.addOutput(addr1, coin.value - 1000);
         chaincoins.sign(mtx);
         assert(mtx.verify());
-        const tx = mtx.toTX();
+        tx = mtx.toTX();
+
+        hashes.push(tx.hash());
+
         await mempool.addTX(tx);
       }
 
       // Attempt to evict the whole batch by replacing the first TX (tx1)
       const mtx2 = new MTX();
       mtx2.addCoin(coin0);
-      mtx2.addOutput(addr1, coin0.value - 1000);
+      mtx2.addCoin(coin1);
+      // Send with massive fee to pay for 100 evicted TXs
+      mtx2.addOutput(addr1, 5000);
       chaincoins.sign(mtx2);
       assert(mtx2.verify());
       const tx2 = mtx2.toTX();
@@ -1390,6 +1429,19 @@ describe('Mempool', function() {
         type: 'VerifyError',
         reason: 'too many potential replacements'
       });
+
+      // Manually remove one of the descendants in advance
+      const entry = mempool.getEntry(tx.hash());
+      mempool.evictEntry(entry);
+
+      // Send back the same TX
+      await mempool.addTX(tx2);
+
+      // Entire mess has been replaced by tx2
+      assert(mempool.has(tx2.hash()));
+      assert(!mempool.has(tx1.hash()));
+      for (const hash of hashes)
+        assert(!mempool.has(hash));
     });
   });
 });


### PR DESCRIPTION
This PR moves the Replacement TXs checks inside the for loop which ensures that if there are more than 100 replacement txs then not to carry out further checks and stop the process.